### PR TITLE
解决了luci里面协议没有auth_chain_a的蛋疼情况

### DIFF
--- a/files/usr/lib/lua/luci/model/cbi/shadowsocksr/general.lua
+++ b/files/usr/lib/lua/luci/model/cbi/shadowsocksr/general.lua
@@ -70,6 +70,7 @@ protocol:value("auth_sha1_v2")
 protocol:value("auth_sha1_v4")
 protocol:value("auth_aes128_sha1")
 protocol:value("auth_aes128_md5")
+protocol:value("auth_chain_a")
 
 obfs = s:option(ListValue, "obfs", translate("Obfs"))
 obfs:value("plain")


### PR DESCRIPTION
解决了一个蛋疼的情况（
shadowsocksR-libev能支持了结果这个luci没有跟进
已在Ubuntu14.04成功编译并在OpenWrt15.05下成功运行并抽到了好多SSR（大雾）

很惭愧只是做了一点微小的工作
今天算是得罪了作者一下